### PR TITLE
Fix issue with wrong key in mapping

### DIFF
--- a/internal/api/grpc_service.go
+++ b/internal/api/grpc_service.go
@@ -492,9 +492,6 @@ func (s *GrpcService) GetDeviceCompatibilities(ctx context.Context, in *p_grpc.G
 
 		for _, f := range features {
 			fkey := f.FeatureKey
-			if fkey == "tires" {
-				fkey = "tires.frontLeft"
-			}
 			ft := &p_grpc.Feature{
 				Key:          integFeats[fkey],
 				SupportLevel: int32(f.SupportLevel),

--- a/internal/core/queries/device_compatibility.go
+++ b/internal/core/queries/device_compatibility.go
@@ -44,7 +44,7 @@ func (dc GetDeviceCompatibilityQueryHandler) Handle(ctx context.Context, query m
 
 	integFeats := make(map[string]string, len(inf))
 	for _, k := range inf {
-		integFeats[k.ElasticProperty] = k.DisplayName
+		integFeats[k.FeatureKey] = k.DisplayName
 	}
 
 	res, err := dc.Repository.FetchDeviceCompatibility(ctx, qry.MakeID, qry.IntegrationID, qry.Region)


### PR DESCRIPTION
# Proposed Changes

This hotfix fixes an issue with the a key used in the response from the grpc endpoint

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->