### PR TITLE
EXP-218 image url fallback to images table

### DIFF
--- a/internal/core/common/utils.go
+++ b/internal/core/common/utils.go
@@ -211,6 +211,16 @@ func BuildFromDeviceDefinitionToQueryResult(dd *repoModel.DeviceDefinition) (*mo
 			})
 		}
 	}
+	// trying pulling fuel images if no image_url, pick the biggest one
+	if (dd.ImageURL.IsZero() || dd.ImageURL.String == "") && dd.R.Images != nil {
+		w := 0
+		for _, image := range dd.R.Images {
+			if image.Width.Int > w {
+				w = image.Width.Int
+				rp.ImageURL = image.SourceURL
+			}
+		}
+	}
 
 	return rp, nil
 }

--- a/internal/infrastructure/db/repositories/device_definition_repo.go
+++ b/internal/infrastructure/db/repositories/device_definition_repo.go
@@ -45,6 +45,7 @@ func (r *deviceDefinitionRepository) GetByMakeModelAndYears(ctx context.Context,
 		models.DeviceDefinitionWhere.Year.EQ(int16(year)),
 		qm.Load(models.DeviceDefinitionRels.DeviceMake),
 		qm.Load(models.DeviceDefinitionRels.DeviceType),
+		qm.Load(models.DeviceDefinitionRels.Images),
 	}
 	if loadIntegrations {
 		qms = append(qms,
@@ -72,6 +73,7 @@ func (r *deviceDefinitionRepository) GetBySlugAndYear(ctx context.Context, slug 
 		models.DeviceDefinitionWhere.Year.EQ(int16(year)),
 		qm.Load(models.DeviceDefinitionRels.DeviceMake),
 		qm.Load(models.DeviceDefinitionRels.DeviceType),
+		qm.Load(models.DeviceDefinitionRels.Images),
 	}
 	if loadIntegrations {
 		qms = append(qms,
@@ -120,6 +122,7 @@ func (r *deviceDefinitionRepository) GetByID(ctx context.Context, id string) (*m
 		qm.Load(models.DeviceDefinitionRels.DeviceIntegrations),
 		qm.Load(models.DeviceDefinitionRels.DeviceMake),
 		qm.Load(models.DeviceDefinitionRels.DeviceType),
+		qm.Load(models.DeviceDefinitionRels.Images),
 		qm.Load(qm.Rels(models.DeviceDefinitionRels.DeviceIntegrations, models.DeviceIntegrationRels.Integration)),
 		qm.Load(models.DeviceDefinitionRels.DeviceStyles)).
 		One(ctx, r.DBS().Reader)


### PR DESCRIPTION
# Proposed Changes
- if image url is empty, try looking in images table for a backup image - picking largest image

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->
grpc endpoints for getting a device definition, get dd by ID

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->