### PR TITLE
EXP-297 vin override support for most

### DIFF
--- a/cmd/device-definitions-api/populate_device_features.go
+++ b/cmd/device-definitions-api/populate_device_features.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 	"strings"
 
 	"github.com/DIMO-Network/device-definitions-api/internal/config"
@@ -13,6 +12,7 @@ import (
 	"github.com/DIMO-Network/shared/db"
 	"github.com/rs/zerolog"
 	"github.com/volatiletech/sqlboiler/v4/boil"
+	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 )
 
 type jsonObj map[string]any

--- a/internal/core/queries/device_compatibility.go
+++ b/internal/core/queries/device_compatibility.go
@@ -3,6 +3,7 @@ package queries
 import (
 	"context"
 	"fmt"
+
 	"github.com/DIMO-Network/device-definitions-api/internal/infrastructure/db/models"
 	"github.com/DIMO-Network/device-definitions-api/internal/infrastructure/db/repositories"
 	"github.com/DIMO-Network/device-definitions-api/internal/infrastructure/exceptions"

--- a/internal/infrastructure/elasticsearch/query_device_features.go
+++ b/internal/infrastructure/elasticsearch/query_device_features.go
@@ -33,6 +33,7 @@ type DeviceFeaturesResp struct {
 	}
 }
 
+// GetDeviceFeatures queries elastic for the presence of the given filterList (integration_features), returns all of them regardless if seen or not
 func (d *ElasticSearch) GetDeviceFeatures(envName, filterList string) (DeviceFeaturesResp, error) {
 	url := fmt.Sprintf("%s/device-status-%s-*/_search", d.BaseURL, envName)
 	body := `


### PR DESCRIPTION
# Proposed Changes
- if key is vin, automatically support for all makes above 2011 except skoda
- merc automatic support 2006+

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->
