### PR TITLE
Return Integration Options with features first

### DIFF
--- a/internal/core/queries/get_integ_options.go
+++ b/internal/core/queries/get_integ_options.go
@@ -31,12 +31,13 @@ func (ch GetIntegrationOptionsQueryHandler) Handle(ctx context.Context, query me
 	qry := query.(*GetIntegrationOptionsQuery)
 	// could pull this one from cache since doesn't change often, although we have frontend caching from explorer
 	var options []*IntegrationOption
-	// raw query to keep performant
+	// raw query to keep performant, note this may duplicate entries where features is null. we want integrations with features first
 	err := queries.Raw(`select di.integration_id, i.vendor, di.region from device_integrations di
 	join integrations i on i.id = di.integration_id
 	join device_definitions dd on dd.id = di.device_definition_id
 	where dd.device_make_id = $1
-	group by di.integration_id, i.vendor, di.region`, qry.MakeID).Bind(ctx, ch.DBS().Reader, &options)
+	group by di.integration_id, i.vendor, di.region, di.features
+    order by di.features is not null desc`, qry.MakeID).Bind(ctx, ch.DBS().Reader, &options)
 
 	if err != nil {
 		return nil, &exceptions.InternalError{
@@ -44,14 +45,19 @@ func (ch GetIntegrationOptionsQueryHandler) Handle(ctx context.Context, query me
 		}
 	}
 
-	// build up grpc object
-	resp := &p_grpc.GetIntegrationOptionsResponse{IntegrationOptions: make([]*p_grpc.GetIntegrationOptionItem, len(options))}
-	for i, option := range options {
-		resp.IntegrationOptions[i] = &p_grpc.GetIntegrationOptionItem{
+	// build up grpc object, ignoring duplicate vendor regions since b/c of group by above may be coming duplicated, but
+	// we want the first ones as those are in the order we want, prioritizing by integrations with features.
+	resp := &p_grpc.GetIntegrationOptionsResponse{IntegrationOptions: make([]*p_grpc.GetIntegrationOptionItem, 0)}
+	for _, option := range options {
+		// ignore if already seen vendor & region
+		if contains(option, resp.IntegrationOptions) {
+			continue
+		}
+		resp.IntegrationOptions = append(resp.IntegrationOptions, &p_grpc.GetIntegrationOptionItem{
 			IntegrationId:     option.IntegrationID,
 			IntegrationVendor: option.IntegrationVendor,
 			Region:            option.Region,
-		}
+		})
 	}
 
 	return resp, nil
@@ -61,4 +67,14 @@ type IntegrationOption struct {
 	IntegrationID     string `boil:"integration_id"`
 	IntegrationVendor string `boil:"vendor"`
 	Region            string `boil:"region"`
+}
+
+func contains(option *IntegrationOption, responseItems []*p_grpc.GetIntegrationOptionItem) bool {
+	for _, integrationOption := range responseItems {
+		if integrationOption.IntegrationVendor == option.IntegrationVendor &&
+			integrationOption.Region == option.Region {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
# Proposed Changes
Wanted to improve the experience on the frontend so that the integration options to show first were those with features in them, so the table would appear better populated at first. 

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->
need to dedupe due to if add another group by changes the sub queries order by order