### PR TITLE
EXP-299 calculate level taking into account EV only makes

### DIFF
--- a/internal/infrastructure/db/migrations/20221121163126_powertrain_integ_feats.sql
+++ b/internal/infrastructure/db/migrations/20221121163126_powertrain_integ_feats.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+
+SET search_path = device_definitions_api, public;
+CREATE TYPE powertrain AS ENUM
+    ('ALL', 'HybridsAndICE', 'ICE', 'HEV', 'PHEV', 'BEV', 'FCEV');
+
+alter table integration_features add column powertrain_type powertrain default 'ALL';
+-- set some known expectations for BEV vs hybrids and ICE
+update integration_features set powertrain_type = 'BEV' where feature_key = 'ev_battery';
+update integration_features set powertrain_type = 'HybridsAndICE' where feature_key = 'battery_voltage';
+update integration_features set powertrain_type = 'HybridsAndICE' where feature_key = 'fuel_percent_remaining';
+update integration_features set powertrain_type = 'HybridsAndICE' where feature_key = 'oil';
+update integration_features set powertrain_type = 'BEV' where feature_key = 'battery_capacity';
+update integration_features set powertrain_type = 'BEV' where feature_key = 'charging';
+update integration_features set powertrain_type = 'HybridsAndICE' where feature_key = 'coolant_temperature';
+update integration_features set powertrain_type = 'BEV' where feature_key = 'battery_capacity';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+
+SET search_path = device_definitions_api, public;
+
+alter table integration_features drop column powertrain_type;
+drop type powertrain;
+
+-- +goose StatementEnd

--- a/internal/infrastructure/db/migrations/20221121163126_powertrain_integ_feats.sql
+++ b/internal/infrastructure/db/migrations/20221121163126_powertrain_integ_feats.sql
@@ -6,7 +6,7 @@ SET search_path = device_definitions_api, public;
 CREATE TYPE powertrain AS ENUM
     ('ALL', 'HybridsAndICE', 'ICE', 'HEV', 'PHEV', 'BEV', 'FCEV');
 
-alter table integration_features add column powertrain_type powertrain default 'ALL';
+alter table integration_features add column powertrain_type powertrain NOT NULL default 'ALL';
 -- set some known expectations for BEV vs hybrids and ICE
 update integration_features set powertrain_type = 'BEV' where feature_key = 'ev_battery';
 update integration_features set powertrain_type = 'HybridsAndICE' where feature_key = 'battery_voltage';

--- a/internal/infrastructure/db/models/boil_types.go
+++ b/internal/infrastructure/db/models/boil_types.go
@@ -51,6 +51,29 @@ func makeCacheKey(cols boil.Columns, nzDefaults []string) string {
 	return str
 }
 
+// Enum values for Powertrain
+const (
+	PowertrainALL           string = "ALL"
+	PowertrainHybridsAndICE string = "HybridsAndICE"
+	PowertrainICE           string = "ICE"
+	PowertrainHEV           string = "HEV"
+	PowertrainPHEV          string = "PHEV"
+	PowertrainBEV           string = "BEV"
+	PowertrainFCEV          string = "FCEV"
+)
+
+func AllPowertrain() []string {
+	return []string{
+		PowertrainALL,
+		PowertrainHybridsAndICE,
+		PowertrainICE,
+		PowertrainHEV,
+		PowertrainPHEV,
+		PowertrainBEV,
+		PowertrainFCEV,
+	}
+}
+
 // Enum values for IntegrationType
 const (
 	IntegrationTypeHardware string = "Hardware"

--- a/internal/infrastructure/db/models/integration_features.go
+++ b/internal/infrastructure/db/models/integration_features.go
@@ -31,6 +31,7 @@ type IntegrationFeature struct {
 	CreatedAt       time.Time    `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
 	UpdatedAt       time.Time    `boil:"updated_at" json:"updated_at" toml:"updated_at" yaml:"updated_at"`
 	FeatureWeight   null.Float64 `boil:"feature_weight" json:"feature_weight,omitempty" toml:"feature_weight" yaml:"feature_weight,omitempty"`
+	PowertrainType  null.String  `boil:"powertrain_type" json:"powertrain_type,omitempty" toml:"powertrain_type" yaml:"powertrain_type,omitempty"`
 
 	R *integrationFeatureR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L integrationFeatureL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -44,6 +45,7 @@ var IntegrationFeatureColumns = struct {
 	CreatedAt       string
 	UpdatedAt       string
 	FeatureWeight   string
+	PowertrainType  string
 }{
 	FeatureKey:      "feature_key",
 	ElasticProperty: "elastic_property",
@@ -52,6 +54,7 @@ var IntegrationFeatureColumns = struct {
 	CreatedAt:       "created_at",
 	UpdatedAt:       "updated_at",
 	FeatureWeight:   "feature_weight",
+	PowertrainType:  "powertrain_type",
 }
 
 var IntegrationFeatureTableColumns = struct {
@@ -62,6 +65,7 @@ var IntegrationFeatureTableColumns = struct {
 	CreatedAt       string
 	UpdatedAt       string
 	FeatureWeight   string
+	PowertrainType  string
 }{
 	FeatureKey:      "integration_features.feature_key",
 	ElasticProperty: "integration_features.elastic_property",
@@ -70,6 +74,7 @@ var IntegrationFeatureTableColumns = struct {
 	CreatedAt:       "integration_features.created_at",
 	UpdatedAt:       "integration_features.updated_at",
 	FeatureWeight:   "integration_features.feature_weight",
+	PowertrainType:  "integration_features.powertrain_type",
 }
 
 // Generated where
@@ -120,6 +125,7 @@ var IntegrationFeatureWhere = struct {
 	CreatedAt       whereHelpertime_Time
 	UpdatedAt       whereHelpertime_Time
 	FeatureWeight   whereHelpernull_Float64
+	PowertrainType  whereHelpernull_String
 }{
 	FeatureKey:      whereHelperstring{field: "\"device_definitions_api\".\"integration_features\".\"feature_key\""},
 	ElasticProperty: whereHelperstring{field: "\"device_definitions_api\".\"integration_features\".\"elastic_property\""},
@@ -128,6 +134,7 @@ var IntegrationFeatureWhere = struct {
 	CreatedAt:       whereHelpertime_Time{field: "\"device_definitions_api\".\"integration_features\".\"created_at\""},
 	UpdatedAt:       whereHelpertime_Time{field: "\"device_definitions_api\".\"integration_features\".\"updated_at\""},
 	FeatureWeight:   whereHelpernull_Float64{field: "\"device_definitions_api\".\"integration_features\".\"feature_weight\""},
+	PowertrainType:  whereHelpernull_String{field: "\"device_definitions_api\".\"integration_features\".\"powertrain_type\""},
 }
 
 // IntegrationFeatureRels is where relationship names are stored.
@@ -147,9 +154,9 @@ func (*integrationFeatureR) NewStruct() *integrationFeatureR {
 type integrationFeatureL struct{}
 
 var (
-	integrationFeatureAllColumns            = []string{"feature_key", "elastic_property", "display_name", "css_icon", "created_at", "updated_at", "feature_weight"}
+	integrationFeatureAllColumns            = []string{"feature_key", "elastic_property", "display_name", "css_icon", "created_at", "updated_at", "feature_weight", "powertrain_type"}
 	integrationFeatureColumnsWithoutDefault = []string{"feature_key", "elastic_property", "display_name"}
-	integrationFeatureColumnsWithDefault    = []string{"css_icon", "created_at", "updated_at", "feature_weight"}
+	integrationFeatureColumnsWithDefault    = []string{"css_icon", "created_at", "updated_at", "feature_weight", "powertrain_type"}
 	integrationFeaturePrimaryKeyColumns     = []string{"feature_key"}
 	integrationFeatureGeneratedColumns      = []string{}
 )

--- a/internal/infrastructure/db/models/integration_features.go
+++ b/internal/infrastructure/db/models/integration_features.go
@@ -31,7 +31,7 @@ type IntegrationFeature struct {
 	CreatedAt       time.Time    `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
 	UpdatedAt       time.Time    `boil:"updated_at" json:"updated_at" toml:"updated_at" yaml:"updated_at"`
 	FeatureWeight   null.Float64 `boil:"feature_weight" json:"feature_weight,omitempty" toml:"feature_weight" yaml:"feature_weight,omitempty"`
-	PowertrainType  null.String  `boil:"powertrain_type" json:"powertrain_type,omitempty" toml:"powertrain_type" yaml:"powertrain_type,omitempty"`
+	PowertrainType  string       `boil:"powertrain_type" json:"powertrain_type" toml:"powertrain_type" yaml:"powertrain_type"`
 
 	R *integrationFeatureR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L integrationFeatureL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -125,7 +125,7 @@ var IntegrationFeatureWhere = struct {
 	CreatedAt       whereHelpertime_Time
 	UpdatedAt       whereHelpertime_Time
 	FeatureWeight   whereHelpernull_Float64
-	PowertrainType  whereHelpernull_String
+	PowertrainType  whereHelperstring
 }{
 	FeatureKey:      whereHelperstring{field: "\"device_definitions_api\".\"integration_features\".\"feature_key\""},
 	ElasticProperty: whereHelperstring{field: "\"device_definitions_api\".\"integration_features\".\"elastic_property\""},
@@ -134,7 +134,7 @@ var IntegrationFeatureWhere = struct {
 	CreatedAt:       whereHelpertime_Time{field: "\"device_definitions_api\".\"integration_features\".\"created_at\""},
 	UpdatedAt:       whereHelpertime_Time{field: "\"device_definitions_api\".\"integration_features\".\"updated_at\""},
 	FeatureWeight:   whereHelpernull_Float64{field: "\"device_definitions_api\".\"integration_features\".\"feature_weight\""},
-	PowertrainType:  whereHelpernull_String{field: "\"device_definitions_api\".\"integration_features\".\"powertrain_type\""},
+	PowertrainType:  whereHelperstring{field: "\"device_definitions_api\".\"integration_features\".\"powertrain_type\""},
 }
 
 // IntegrationFeatureRels is where relationship names are stored.


### PR DESCRIPTION
# Proposed Changes
- add powertrain to integration_features
- if tesla, rivian or lucid, remove any non EV items for calculations

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->
- This won't work the other way around for ICE vehicles that should not consider EV features.
- This won't work for EV's from other traditional makes
- Future work here will require having the powertrain value in device_definition which we currently do not have. 