### PR TITLE
SM-1188: use all providers always, set trx hash resp

### DIFF
--- a/internal/api/handlers/device_definition_handler.go
+++ b/internal/api/handlers/device_definition_handler.go
@@ -19,7 +19,7 @@ import (
 // @Produce json
 // @Accept json
 // @Param  decodeRequest body DecodeVINRequest true  "Decode VIN request"
-// @Success 200 {object} DecodeVINResponse "Response with definition ID. TODO return polygon transaction if new DD"
+// @Success 200 {object} DecodeVINResponse "Response with definition ID.
 // @Failure 404
 // @Failure 500
 // @Security    BearerAuth
@@ -40,7 +40,7 @@ func DecodeVIN(m mediator.Mediator) fiber.Handler {
 		dd := DecodeVINResponse{
 			DeviceDefinitionID: resp.NameSlug,
 			LegacyID:           resp.DeviceDefinitionId,
-			// todo add the tableland trx if any
+			NewTransactionHash: resp.NewTrxHash,
 		}
 
 		return c.Status(fiber.StatusOK).JSON(dd)

--- a/internal/core/queries/decode_vin.go
+++ b/internal/core/queries/decode_vin.go
@@ -200,23 +200,16 @@ func (dc DecodeVINQueryHandler) Handle(ctx context.Context, query mediator.Messa
 	}
 	// future: see if we can self decode model based on data we have before calling external decode WMI and VDS. Only thing is we won't get the style.
 
-	var vinInfo = &coremodels.VINDecodingInfoData{}
-	// if year is 0 or way in future, prefer datgroup, autoiso and vincario for decode, since most likely non USA.
 	if resp.Year == 0 || resp.Year > int32(time.Now().Year()+1) {
 		localLog.Info().Msgf("encountered vin with non-standard year digit")
-		vinInfo, err = dc.vinDecodingService.GetVIN(ctx, vin.String(), dt, coremodels.DATGroupProvider, qry.Country)
-		if err != nil {
-			localLog.Err(err).Msg("failed to GetVIN with DATGroupProvider")
-			vinInfo, err = dc.vinDecodingService.GetVIN(ctx, vin.String(), dt, coremodels.VincarioProvider, qry.Country)
-		}
-	} else {
-		vinInfo, err = dc.vinDecodingService.GetVIN(ctx, vin.String(), dt, coremodels.AllProviders, qry.Country) // this will try drivly first
 	}
+	vinInfo, err := dc.vinDecodingService.GetVIN(ctx, vin.String(), dt, coremodels.AllProviders, qry.Country) // this will try drivly first
 
 	// if no luck decoding VIN, try buildingVinInfo from known data passed in
 	if err != nil {
 		if len(qry.KnownModel) > 0 && qry.KnownYear > 0 {
 			// note if this is successful, err gets set to nil
+			// todo: the knownModel should correspond with the Make
 			vinInfo, err = dc.vinInfoFromKnown(vin, qry.KnownModel, qry.KnownYear)
 		}
 	}


### PR DESCRIPTION
# Proposed Changes
- set the trx hash response
- use all the decode vendors always

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->