### PR TITLE
Intg-1310 decode tesla vin through internal decoder

### DIFF
--- a/cmd/device-definitions-api/sync_r1_compatibility.go
+++ b/cmd/device-definitions-api/sync_r1_compatibility.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+
 	"github.com/DIMO-Network/device-definitions-api/internal/config"
 	"github.com/DIMO-Network/device-definitions-api/internal/core/queries"
 	"github.com/google/subcommands"

--- a/internal/api/handlers/integration_handler.go
+++ b/internal/api/handlers/integration_handler.go
@@ -89,7 +89,7 @@ var smartcarOems []byte
 // @Failure 500
 // @Router /manufacturers/integrations/smartcar [get]
 func GetSmartcarManufacturers() fiber.Handler {
-	const assetApi = "https://api.dimo.co/assets/logos/"
+	const assetAPI = "https://api.dimo.co/assets/logos/"
 
 	return func(c *fiber.Ctx) error {
 		var jsonContent []map[string]interface{}
@@ -100,7 +100,7 @@ func GetSmartcarManufacturers() fiber.Handler {
 		// Prepend the url path to each "logo" field in the array
 		for _, item := range jsonContent {
 			if logo, ok := item["logo"].(string); ok {
-				item["logo"] = assetApi + logo
+				item["logo"] = assetAPI + logo
 			}
 		}
 

--- a/internal/core/models/vin_decoding_models.go
+++ b/internal/core/models/vin_decoding_models.go
@@ -12,6 +12,7 @@ const (
 	AutoIsoProvider  DecodeProviderEnum = "autoiso"
 	DATGroupProvider DecodeProviderEnum = "dat"
 	AllProviders     DecodeProviderEnum = ""
+	TeslaProvider    DecodeProviderEnum = "tesla"
 )
 
 type VINDecodingInfoData struct {

--- a/internal/core/queries/decode_vin.go
+++ b/internal/core/queries/decode_vin.go
@@ -139,7 +139,7 @@ func (dc DecodeVINQueryHandler) Handle(ctx context.Context, query mediator.Messa
 		return resp, nil
 	}
 
-	// If DeviceDefinitionID passed in, override VIN decoding // todo next version: this should change to use definitionId
+	// If DeviceDefinitionID passed in, override VIN decoding
 	localLog.Info().Msgf("Start Decode VIN for vin %s and device definition %s", vin.String(), qry.DefinitionID)
 	if len(qry.DefinitionID) > 0 {
 		tblDef, _, err := dc.deviceDefinitionOnChainService.GetDefinitionByID(ctx, qry.DefinitionID, dc.dbs().Reader)
@@ -222,7 +222,8 @@ func (dc DecodeVINQueryHandler) Handle(ctx context.Context, query mediator.Messa
 		if dbWMI.R.DeviceMake != nil && dbWMI.R.DeviceMake.Name == "Tesla" {
 			vinInfo, err = dc.vinDecodingService.GetVIN(ctx, vin.String(), dt, coremodels.TeslaProvider, qry.Country)
 		}
-	} else {
+	}
+	if vinInfo == nil || vinInfo.Model == "" {
 		vinInfo, err = dc.vinDecodingService.GetVIN(ctx, vin.String(), dt, coremodels.AllProviders, qry.Country) // this will try drivly first
 	}
 

--- a/internal/core/queries/decode_vin_test.go
+++ b/internal/core/queries/decode_vin_test.go
@@ -562,8 +562,8 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_TeslaDecode() {
 	definitionID := dd.NameSlug
 
 	s.mockVINService.EXPECT().GetVIN(ctx, vin, gomock.Any(), coremodels.TeslaProvider, "USA").Times(1).Return(vinDecodingInfoData, nil)
-	ddId := "tesla_model-3_2023"
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "tesla", "model-3", &ddId, gomock.Any(), gomock.Any()).Return("BEV", nil)
+	ddID := "tesla_model-3_2023"
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "tesla", "model-3", &ddID, gomock.Any(), gomock.Any()).Return("BEV", nil)
 	s.mockDeviceDefinitionOnChainService.EXPECT().GetDefinitionByID(gomock.Any(), definitionID, gomock.Any()).Return(
 		buildTestTblDD(definitionID, dd.Model, int(dd.Year)), nil, nil)
 	wmiDb := &models.Wmi{

--- a/internal/core/queries/decode_vin_test.go
+++ b/internal/core/queries/decode_vin_test.go
@@ -538,6 +538,66 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_WithExistingWMI() {
 	s.Assert().Len(wmis, 1)
 }
 
+func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_TeslaDecode() {
+	ctx := context.Background()
+	const vin = "5YJ3E1EA2PF696023" // tesla model 3 2023
+
+	_ = dbtesthelper.SetupCreateAutoPiIntegration(s.T(), s.pdb)
+	dm := dbtesthelper.SetupCreateMake(s.T(), "Tesla", s.pdb)
+	dd := dbtesthelper.SetupCreateDeviceDefinitionWithVehicleInfo(s.T(), dm, "Model 3", 2023, s.pdb)
+	wmi := models.Wmi{
+		Wmi:          "5YJ",
+		DeviceMakeID: dm.ID,
+	}
+	err := wmi.Insert(s.ctx, s.pdb.DBS().Writer, boil.Infer())
+	s.Require().NoError(err)
+
+	vinDecodingInfoData := &coremodels.VINDecodingInfoData{
+		Make:   "Tesla",
+		Source: "tesla",
+		Year:   int32(2023),
+		Model:  "Model 3",
+	}
+
+	definitionID := dd.NameSlug
+
+	s.mockVINService.EXPECT().GetVIN(ctx, vin, gomock.Any(), coremodels.TeslaProvider, "USA").Times(1).Return(vinDecodingInfoData, nil)
+	ddId := "tesla_model-3_2023"
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "tesla", "model-3", &ddId, gomock.Any(), gomock.Any()).Return("BEV", nil)
+	s.mockDeviceDefinitionOnChainService.EXPECT().GetDefinitionByID(gomock.Any(), definitionID, gomock.Any()).Return(
+		buildTestTblDD(definitionID, dd.Model, int(dd.Year)), nil, nil)
+	wmiDb := &models.Wmi{
+		Wmi:          vin[:3],
+		DeviceMakeID: dm.ID,
+	}
+	wmiDb.R = wmiDb.R.NewStruct()
+	wmiDb.R.DeviceMake = &dm
+
+	image := gateways.FuelImage{
+		SourceURL: "https://image",
+	}
+	fuelDeviceImagesMock := gateways.FuelDeviceImages{
+		FuelAPIID: "1",
+		Height:    1,
+		Width:     1,
+		Images:    []gateways.FuelImage{image},
+	}
+	s.mockFuelAPIService.EXPECT().FetchDeviceImages(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(fuelDeviceImagesMock, nil)
+
+	qryResult, err := s.queryHandler.Handle(s.ctx, &DecodeVINQuery{VIN: vin, Country: country})
+	s.NoError(err)
+	result := qryResult.(*p_grpc.DecodeVinResponse)
+
+	s.NotNil(result, "expected result not nil")
+	s.Assert().Equal(int32(2023), result.Year)
+	s.Assert().Equal(dd.NameSlug, result.DefinitionId)
+	s.Assert().Equal(dm.ID, result.DeviceMakeId)
+	// validate same number of wmi's
+	wmis, err := models.Wmis().All(s.ctx, s.pdb.DBS().Reader)
+	s.Require().NoError(err)
+	s.Assert().Len(wmis, 1)
+}
+
 func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_WithExistingVINNumber() {
 	const vin = "1FMCU0G61MUA52727" // ford escape 2021
 

--- a/internal/core/queries/decode_vin_test.go
+++ b/internal/core/queries/decode_vin_test.go
@@ -281,7 +281,6 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_CreatesDD() {
 	}
 	wmiDb.R = wmiDb.R.NewStruct()
 	wmiDb.R.DeviceMake = &dm
-	s.mockVINRepo.EXPECT().GetOrCreateWMI(gomock.Any(), vin[:3], dm.Name).Return(wmiDb, nil)
 
 	image := gateways.FuelImage{
 		SourceURL: "https://image",
@@ -513,7 +512,6 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_WithExistingWMI() {
 	}
 	wmiDb.R = wmiDb.R.NewStruct()
 	wmiDb.R.DeviceMake = &dm
-	s.mockVINRepo.EXPECT().GetOrCreateWMI(gomock.Any(), vin[:3], dm.Name).Return(wmiDb, nil)
 
 	image := gateways.FuelImage{
 		SourceURL: "https://image",
@@ -729,7 +727,6 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_DecodeKnownFallback() {
 	}
 	wmiDb.R = wmiDb.R.NewStruct()
 	wmiDb.R.DeviceMake = &dm
-	s.mockVINRepo.EXPECT().GetOrCreateWMI(gomock.Any(), vin[:3], dm.Name).Return(wmiDb, nil)
 
 	qryResult, err := s.queryHandler.Handle(s.ctx, &DecodeVINQuery{VIN: vin, Country: country,
 		KnownYear:  2022,

--- a/internal/core/services/vin_decoding_service.go
+++ b/internal/core/services/vin_decoding_service.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/DIMO-Network/shared"
+	"github.com/volatiletech/null/v8"
 	"regexp"
 	"strconv"
 	"strings"
@@ -24,6 +26,7 @@ import (
 )
 
 type VINDecodingService interface {
+	// GetVIN decodes a vin using one of the providers passed in or if AllProviders applies an ordered logic. Only pass TeslaProvider if know it is a Tesla.
 	GetVIN(ctx context.Context, vin string, dt *repoModel.DeviceType, provider models.DecodeProviderEnum, country string) (*models.VINDecodingInfoData, error)
 }
 
@@ -64,6 +67,22 @@ func (c vinDecodingService) GetVIN(ctx context.Context, vin string, dt *repoMode
 	}
 
 	switch provider {
+	case models.TeslaProvider:
+		v := shared.VIN(vin)
+		metadata := map[string]interface{}{
+			"fuel_type":       "electric",
+			"powertrain_type": models.BEV.String(),
+		}
+		bytes, _ := json.Marshal(metadata)
+		result = &models.VINDecodingInfoData{
+			VIN:      vin,
+			Year:     int32(v.Year()),
+			Make:     "Tesla",
+			Model:    v.TeslaModel(),
+			Source:   models.TeslaProvider,
+			FuelType: "electric",
+			MetaData: null.JSONFrom(bytes),
+		}
 	case models.DrivlyProvider:
 		vinDrivlyInfo, err := c.drivlyAPISvc.GetVINInfo(vin)
 		if err != nil {
@@ -102,6 +121,8 @@ func (c vinDecodingService) GetVIN(ctx context.Context, vin string, dt *repoMode
 			return nil, err
 		}
 	case models.AllProviders:
+		// todo if tesla, just build from tesla and use model
+
 		vinDrivlyInfo, err := c.drivlyAPISvc.GetVINInfo(vin)
 		if err != nil {
 			localLog.Warn().Err(err).Msg("AllProviders decode - unable decode vin with drivly")

--- a/internal/core/services/vin_decoding_service.go
+++ b/internal/core/services/vin_decoding_service.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/DIMO-Network/shared"
-	"github.com/volatiletech/null/v8"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/DIMO-Network/shared"
+	"github.com/volatiletech/null/v8"
 
 	"github.com/DIMO-Network/device-definitions-api/internal/infrastructure/db/repositories"
 

--- a/internal/core/services/vin_decoding_service_test.go
+++ b/internal/core/services/vin_decoding_service_test.go
@@ -115,6 +115,20 @@ func (s *VINDecodingServiceSuite) Test_VINDecodingService_Drivly_Success() {
 	assert.Equal(s.T(), result.Source, coremodels.DrivlyProvider)
 }
 
+func (s *VINDecodingServiceSuite) Test_VINDecodingService_Tesla() {
+	ctx := context.Background()
+	const vin = "5YJ3E1EA2PF696023"
+	dt := dbtesthelper.SetupCreateDeviceType(s.T(), s.pdb)
+	result, err := s.vinDecodingService.GetVIN(ctx, vin, dt, coremodels.TeslaProvider, "USA")
+
+	s.NoError(err)
+	assert.Equal(s.T(), result.VIN, vin)
+	assert.Equal(s.T(), result.Make, "Tesla")
+	assert.Equal(s.T(), result.Model, "Model 3")
+	assert.Equal(s.T(), string(result.MetaData.JSON), `{"fuel_type":"electric","powertrain_type":"BEV"}`)
+	assert.Equal(s.T(), result.Source, coremodels.TeslaProvider)
+}
+
 func (s *VINDecodingServiceSuite) Test_VINDecodingService_Vincario_Success() {
 	ctx := context.Background()
 	const vin = "WAUZZZKM04D018683"


### PR DESCRIPTION
# Proposed Changes
if, according to the WMI in our database, the VIN is recognized as a tesla vin, then do not hit an external vendor and decode using our logic in the shared library. 

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->
`/device-definitions/decode-vin`

grpc decode vin

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->