### PR TITLE
remove unnecessary call to tableland in resolve powertrain, add make …

### DIFF
--- a/internal/core/commands/create_dd.go
+++ b/internal/core/commands/create_dd.go
@@ -84,7 +84,7 @@ func (ch CreateDeviceDefinitionCommandHandler) Handle(ctx context.Context, query
 			}
 		}
 		if !powerTrainExists {
-			powerTrainTypeValue, err := ch.powerTrainTypeService.ResolvePowerTrainType(ctx, shared.SlugString(command.Make), shared.SlugString(command.Model), nil, null.JSON{}, null.JSON{})
+			powerTrainTypeValue, err := ch.powerTrainTypeService.ResolvePowerTrainType(shared.SlugString(command.Make), shared.SlugString(command.Model), null.JSON{}, null.JSON{})
 			if err != nil {
 				return nil, &exceptions.InternalError{
 					Err: fmt.Errorf("failed to get powertraintype"),

--- a/internal/core/commands/create_dd_test.go
+++ b/internal/core/commands/create_dd_test.go
@@ -100,7 +100,7 @@ func (s *CreateDeviceDefinitionCommandHandlerSuite) TestCreateDeviceDefinitionCo
 	dd.R.DeviceMake = &models.DeviceMake{ID: deviceMakeID, Name: mk}
 
 	iceValue := "ICE"
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), gomock.Any(), gomock.Any(), nil, null.JSON{}, null.JSON{}).Return(iceValue, nil)
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), gomock.Any(), null.JSON{}, null.JSON{}).Return(iceValue, nil)
 	s.mockDeviceDefRepo.EXPECT().GetOrCreate(gomock.Any(), nil, source, "", mk, model, year, gomock.Any(), gomock.Any(), false, gomock.Any()).Return(dd, nil).Times(1)
 
 	var deviceAttributes []*coremodels.UpdateDeviceTypeAttribute
@@ -133,7 +133,7 @@ func (s *CreateDeviceDefinitionCommandHandlerSuite) TestCreateDeviceDefinitionCo
 	year := 2022
 
 	iceValue := "ICE"
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), gomock.Any(), gomock.Any(), nil, null.JSON{}, null.JSON{}).Return(iceValue, nil)
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), gomock.Any(), null.JSON{}, null.JSON{}).Return(iceValue, nil)
 	s.mockDeviceDefRepo.EXPECT().
 		GetOrCreate(gomock.Any(), nil, source, "", mk, model, year, gomock.Any(), gomock.Any(), false, gomock.Any()).Return(nil, errors.New("Error")).Times(1)
 

--- a/internal/core/commands/sync_dd_power_train_type.go
+++ b/internal/core/commands/sync_dd_power_train_type.go
@@ -96,7 +96,7 @@ func (ch SyncPowerTrainTypeCommandHandler) Handle(ctx context.Context, query med
 							powerTrainTypeValue = &strValue
 						}
 						if powerTrainTypeValue == nil || *powerTrainTypeValue == "" || *powerTrainTypeValue == "null" {
-							pt, err := ch.powerTrainTypeService.ResolvePowerTrainType(ctx, definition.R.DeviceMake.NameSlug, definition.ModelSlug, &definition.ID, null.JSON{}, null.JSON{})
+							pt, err := ch.powerTrainTypeService.ResolvePowerTrainType(definition.R.DeviceMake.NameSlug, definition.ModelSlug, null.JSON{}, null.JSON{})
 							powerTrainTypeValue = &pt
 							if err != nil {
 								ch.logger.Error().Err(err).Stack().Msg("failed to ResolvePowerTrainType")
@@ -105,7 +105,7 @@ func (ch SyncPowerTrainTypeCommandHandler) Handle(ctx context.Context, query med
 							needsUpdate = true
 						} else {
 							if command.ForceUpdate {
-								pt, err := ch.powerTrainTypeService.ResolvePowerTrainType(ctx, definition.R.DeviceMake.NameSlug, definition.ModelSlug, &definition.ID, null.JSON{}, null.JSON{})
+								pt, err := ch.powerTrainTypeService.ResolvePowerTrainType(definition.R.DeviceMake.NameSlug, definition.ModelSlug, null.JSON{}, null.JSON{})
 								powerTrainTypeValue = &pt
 								if err != nil {
 									ch.logger.Error().Err(err).Stack().Msg("failed to ResolvePowerTrainType")
@@ -122,7 +122,7 @@ func (ch SyncPowerTrainTypeCommandHandler) Handle(ctx context.Context, query med
 				}
 
 				if !hasPowerTrainType {
-					pt, err := ch.powerTrainTypeService.ResolvePowerTrainType(ctx, definition.R.DeviceMake.NameSlug, definition.ModelSlug, &definition.ID, null.JSON{}, null.JSON{})
+					pt, err := ch.powerTrainTypeService.ResolvePowerTrainType(definition.R.DeviceMake.NameSlug, definition.ModelSlug, null.JSON{}, null.JSON{})
 					powerTrainTypeValue = &pt
 					if err != nil {
 						ch.logger.Error().Err(err).Stack().Msg("failed to ResolvePowerTrainType")

--- a/internal/core/commands/sync_dd_power_train_type_test.go
+++ b/internal/core/commands/sync_dd_power_train_type_test.go
@@ -66,7 +66,7 @@ func (s *SyncPowerTrainTypeCommandHandlerSuite) TestSyncPowerTrainTypeCommand_Su
 	dd := setupDeviceDefinition(s.T(), s.pdb, mk, model, year)
 
 	ICE := "ICE"
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), null.JSON{}, null.JSON{}).Return(ICE, nil).Times(1)
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), gomock.Any(), null.JSON{}, null.JSON{}).Return(ICE, nil).Times(1)
 
 	qryResult, err := s.queryHandler.Handle(ctx, &SyncPowerTrainTypeCommand{DeviceTypeID: dd.DeviceTypeID.String})
 	require.NoError(s.T(), err, "handler failed to execute")
@@ -104,7 +104,7 @@ func (s *SyncPowerTrainTypeCommandHandlerSuite) TestSyncPowerTrainTypeCommand_Wi
 	dd := setupDeviceDefinitionForPowerTrain(s.T(), s.pdb, mk, model, year)
 
 	HEV := "HEV"
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), null.JSON{}, null.JSON{}).Return(HEV, nil).Times(1)
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), gomock.Any(), null.JSON{}, null.JSON{}).Return(HEV, nil).Times(1)
 
 	qryResult, err := s.queryHandler.Handle(ctx, &SyncPowerTrainTypeCommand{ForceUpdate: true, DeviceTypeID: dd.DeviceTypeID.String})
 	require.NoError(s.T(), err, "handler failed to execute")

--- a/internal/core/queries/decode_vin.go
+++ b/internal/core/queries/decode_vin.go
@@ -127,8 +127,7 @@ func (dc DecodeVINQueryHandler) Handle(ctx context.Context, query mediator.Messa
 		if len(split) != 3 {
 			return nil, errors.New("invalid definition ID encountered: " + vinDecodeNumber.DefinitionID)
 		}
-		pt, err := dc.powerTrainTypeService.ResolvePowerTrainType(ctx, split[0], split[1], &vinDecodeNumber.DefinitionID,
-			vinDecodeNumber.DrivlyData, vinDecodeNumber.VincarioData)
+		pt, err := dc.powerTrainTypeService.ResolvePowerTrainType(split[0], split[1], vinDecodeNumber.DrivlyData, vinDecodeNumber.VincarioData)
 		if err != nil {
 			pt = coremodels.ICE.String()
 		}
@@ -193,7 +192,7 @@ func (dc DecodeVINQueryHandler) Handle(ctx context.Context, query mediator.Messa
 		resp.DeviceMakeId = vinDecodeNumber.DeviceMakeID
 		resp.Year = int32(vinDecodeNumber.Year)
 		resp.Source = vinDecodeNumber.DecodeProvider.String
-		pt, err := dc.powerTrainTypeService.ResolvePowerTrainType(ctx, split[0], split[1], &vinDecodeNumber.DefinitionID, null.JSON{}, null.JSON{})
+		pt, err := dc.powerTrainTypeService.ResolvePowerTrainType(split[0], split[1], null.JSON{}, null.JSON{})
 		if err != nil {
 			pt = coremodels.ICE.String()
 		}
@@ -467,7 +466,7 @@ func (dc DecodeVINQueryHandler) Handle(ctx context.Context, query mediator.Messa
 							} else {
 								vincarioData = vinInfo.MetaData
 							}
-							powerTrainTypeValue, err = dc.powerTrainTypeService.ResolvePowerTrainType(ctx, dd.R.DeviceMake.NameSlug, dd.ModelSlug, &dd.NameSlug, drivlyData, vincarioData)
+							powerTrainTypeValue, err = dc.powerTrainTypeService.ResolvePowerTrainType(dd.R.DeviceMake.NameSlug, dd.ModelSlug, drivlyData, vincarioData)
 							if err != nil {
 								dc.logger.Error().Err(err).Msg("Error when resolve Powertrain")
 							}
@@ -513,7 +512,7 @@ func (dc DecodeVINQueryHandler) Handle(ctx context.Context, query mediator.Messa
 	// if powertrain not set yet, try resolving for it
 	if resp.Powertrain == "" {
 		split := strings.Split(resp.DefinitionId, "_")
-		pt, _ := dc.powerTrainTypeService.ResolvePowerTrainType(ctx, split[0], split[1], &resp.DefinitionId, vinDecodeNumber.DrivlyData, vinDecodeNumber.VincarioData)
+		pt, _ := dc.powerTrainTypeService.ResolvePowerTrainType(split[0], split[1], vinDecodeNumber.DrivlyData, vinDecodeNumber.VincarioData)
 		resp.Powertrain = pt
 	}
 

--- a/internal/core/queries/decode_vin_test.go
+++ b/internal/core/queries/decode_vin_test.go
@@ -403,7 +403,7 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_WithExistingDD_AndStyleA
 	definitionID := dd.NameSlug
 
 	s.mockVINService.EXPECT().GetVIN(ctx, vin, gomock.Any(), coremodels.AllProviders, "USA").Times(1).Return(vinDecodingInfoData, nil)
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "ford", "escape", &dd.NameSlug, gomock.AssignableToTypeOf(null.JSON{}), gomock.AssignableToTypeOf(null.JSON{}))
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType("ford", "escape", gomock.AssignableToTypeOf(null.JSON{}), gomock.AssignableToTypeOf(null.JSON{}))
 	s.mockDeviceDefinitionOnChainService.EXPECT().GetDefinitionByID(gomock.Any(), definitionID, gomock.Any()).Return(
 		buildTestTblDD(definitionID, dd.Model, int(dd.Year)), nil, nil)
 	// db setup
@@ -562,8 +562,7 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_TeslaDecode() {
 	definitionID := dd.NameSlug
 
 	s.mockVINService.EXPECT().GetVIN(ctx, vin, gomock.Any(), coremodels.TeslaProvider, "USA").Times(1).Return(vinDecodingInfoData, nil)
-	ddID := "tesla_model-3_2023"
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "tesla", "model-3", &ddID, gomock.Any(), gomock.Any()).Return("BEV", nil)
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType("tesla", "model-3", gomock.Any(), gomock.Any()).Return("BEV", nil)
 	s.mockDeviceDefinitionOnChainService.EXPECT().GetDefinitionByID(gomock.Any(), definitionID, gomock.Any()).Return(
 		buildTestTblDD(definitionID, dd.Model, int(dd.Year)), nil, nil)
 	wmiDb := &models.Wmi{
@@ -628,7 +627,7 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_WithExistingVINNumber() 
 	err = vinNumb.Insert(s.ctx, s.pdb.DBS().Writer, boil.Infer())
 	s.Require().NoError(err)
 	// when we get the vin already found, we lookup the powertrain using powertrain service
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "ford", "escape", &dd.NameSlug, vinNumb.DrivlyData, vinNumb.VincarioData)
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType("ford", "escape", vinNumb.DrivlyData, vinNumb.VincarioData)
 
 	qryResult, err := s.queryHandler.Handle(s.ctx, &DecodeVINQuery{VIN: vin, Country: country})
 	s.NoError(err)
@@ -658,7 +657,7 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_InvalidVINYear_AutoIso()
 	}
 	definitionID := "ford_escape_2017"
 	s.mockVINService.EXPECT().GetVIN(ctx, vin, gomock.Any(), coremodels.AllProviders, "USA").Times(1).Return(vinDecodingInfoData, nil)
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "ford", "escape", gomock.Any(), gomock.AssignableToTypeOf(null.JSON{}), gomock.AssignableToTypeOf(null.JSON{}))
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType("ford", "escape", gomock.AssignableToTypeOf(null.JSON{}), gomock.AssignableToTypeOf(null.JSON{}))
 	trxHashHex := "0xa90868fe9364dbf41695b3b87e630f6455cfd63a4711f56b64f631b828c02b35"
 	s.mockDeviceDefinitionOnChainService.EXPECT().Create(ctx, gomock.Any(), gomock.Any()).Return(&trxHashHex, nil)
 	s.mockDeviceDefinitionOnChainService.EXPECT().GetDefinitionByID(gomock.Any(), definitionID, gomock.Any()).Return(
@@ -704,7 +703,7 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_InvalidStyleName_AutoIso
 	}
 	definitionID := "ford_escape_2017"
 	s.mockVINService.EXPECT().GetVIN(ctx, vin, gomock.Any(), coremodels.AllProviders, "USA").Times(1).Return(vinDecodingInfoData, nil)
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "ford", "escape", gomock.Any(), gomock.AssignableToTypeOf(null.JSON{}), gomock.AssignableToTypeOf(null.JSON{}))
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType("ford", "escape", gomock.AssignableToTypeOf(null.JSON{}), gomock.AssignableToTypeOf(null.JSON{}))
 	trxHashHex := "0xa90868fe9364dbf41695b3b87e630f6455cfd63a4711f56b64f631b828c02b35"
 	s.mockDeviceDefinitionOnChainService.EXPECT().Create(ctx, gomock.Any(), gomock.Any()).Return(&trxHashHex, nil)
 	s.mockDeviceDefinitionOnChainService.EXPECT().GetDefinitionByID(gomock.Any(), definitionID, gomock.Any()).Return(
@@ -764,7 +763,7 @@ func (s *DecodeVINQueryHandlerSuite) TestHandle_Success_DecodeKnownFallback() {
 
 	definitionID := "ford_bronco_2022"
 	s.mockVINService.EXPECT().GetVIN(ctx, vin, gomock.Any(), coremodels.AllProviders, "USA").Times(1).Return(nil, fmt.Errorf("unable to decode"))
-	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType(gomock.Any(), "ford", "bronco", &definitionID, gomock.AssignableToTypeOf(null.JSON{}), gomock.AssignableToTypeOf(null.JSON{}))
+	s.mockPowerTrainTypeService.EXPECT().ResolvePowerTrainType("ford", "bronco", gomock.AssignableToTypeOf(null.JSON{}), gomock.AssignableToTypeOf(null.JSON{}))
 
 	trxHashHex := "0xa90868fe9364dbf41695b3b87e630f6455cfd63a4711f56b64f631b828c02b35"
 	s.mockDeviceDefinitionOnChainService.EXPECT().Create(ctx, gomock.Any(), gomock.Any()).Return(&trxHashHex, nil)

--- a/internal/core/services/mocks/powertrain_type_service_mock.go
+++ b/internal/core/services/mocks/powertrain_type_service_mock.go
@@ -5,15 +5,15 @@
 //
 //	mockgen -source powertrain_type_service.go -destination mocks/powertrain_type_service_mock.go -package mocks
 //
+
 // Package mocks is a generated GoMock package.
 package mocks
 
 import (
-	context "context"
 	reflect "reflect"
 
 	models "github.com/DIMO-Network/device-definitions-api/internal/core/models"
-	v8 "github.com/volatiletech/null/v8"
+	null "github.com/volatiletech/null/v8"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -55,16 +55,16 @@ func (mr *MockPowerTrainTypeServiceMockRecorder) ResolvePowerTrainFromVinInfo(vi
 }
 
 // ResolvePowerTrainType mocks base method.
-func (m *MockPowerTrainTypeService) ResolvePowerTrainType(ctx context.Context, makeSlug, modelSlug string, definitionID *string, drivlyData, vincarioData v8.JSON) (string, error) {
+func (m *MockPowerTrainTypeService) ResolvePowerTrainType(makeSlug, modelSlug string, drivlyData, vincarioData null.JSON) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolvePowerTrainType", ctx, makeSlug, modelSlug, definitionID, drivlyData, vincarioData)
+	ret := m.ctrl.Call(m, "ResolvePowerTrainType", makeSlug, modelSlug, drivlyData, vincarioData)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolvePowerTrainType indicates an expected call of ResolvePowerTrainType.
-func (mr *MockPowerTrainTypeServiceMockRecorder) ResolvePowerTrainType(ctx, makeSlug, modelSlug, definitionID, drivlyData, vincarioData any) *gomock.Call {
+func (mr *MockPowerTrainTypeServiceMockRecorder) ResolvePowerTrainType(makeSlug, modelSlug, drivlyData, vincarioData any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePowerTrainType", reflect.TypeOf((*MockPowerTrainTypeService)(nil).ResolvePowerTrainType), ctx, makeSlug, modelSlug, definitionID, drivlyData, vincarioData)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePowerTrainType", reflect.TypeOf((*MockPowerTrainTypeService)(nil).ResolvePowerTrainType), makeSlug, modelSlug, drivlyData, vincarioData)
 }

--- a/internal/core/services/powertrain_type_service.go
+++ b/internal/core/services/powertrain_type_service.go
@@ -158,15 +158,18 @@ func (c powerTrainTypeService) ResolvePowerTrainType(makeSlug string, modelSlug 
 }
 
 // powertrainNameInference figures out powertrain just from name
-func powertrainNameInference(name string) string {
-	// model name based inference
-	if strings.Contains(name, "plug-in") {
+func powertrainNameInference(modelSlug string) string {
+	// model modelSlug based inference
+	if strings.Contains(modelSlug, "plug-in") {
 		return coremodels.PHEV.String()
 	}
-	if strings.Contains(name, "hybrid") {
+	if strings.Contains(modelSlug, "hybrid") {
 		return coremodels.HEV.String()
 	}
-	if strings.Contains(name, "e-tron") {
+	if strings.Contains(modelSlug, "e-tron") {
+		return coremodels.BEV.String()
+	}
+	if strings.Contains(modelSlug, "-ev") {
 		return coremodels.BEV.String()
 	}
 

--- a/internal/core/services/powertrain_type_service_test.go
+++ b/internal/core/services/powertrain_type_service_test.go
@@ -135,7 +135,7 @@ func Test_powerTrainTypeService_ResolvePowerTrainType(t *testing.T) {
 				tt.before()
 			}
 
-			got, err := ptSvc.ResolvePowerTrainType(ctx, tt.args.makeSlug, tt.args.modelSlug, tt.args.definitionID, tt.args.drivlyData, tt.args.vincarioData)
+			got, err := ptSvc.ResolvePowerTrainType(tt.args.makeSlug, tt.args.modelSlug, tt.args.drivlyData, tt.args.vincarioData)
 			assert.NoError(t, err)
 
 			assert.Equalf(t, tt.want, got, "ResolvePowerTrainType( %v, %v, %v, %v, %v)", tt.args.makeSlug, tt.args.modelSlug, tt.args.definitionID, tt.args.drivlyData, tt.args.vincarioData)

--- a/internal/core/services/powertrain_type_service_test.go
+++ b/internal/core/services/powertrain_type_service_test.go
@@ -117,17 +117,6 @@ func Test_powerTrainTypeService_ResolvePowerTrainType(t *testing.T) {
 			},
 			want: "BEV",
 		},
-		{
-			name: "device definition already has powertrain - BEV",
-			args: args{
-				definitionID: &ddWithPt.NameSlug,
-			},
-			want: "BEV",
-			before: func() {
-				onChainSvc.EXPECT().GetDefinitionByID(gomock.Any(), ddWithPt.NameSlug, gomock.Any()).
-					Return(buildTestTblDD(ddWithPt.NameSlug, "super-special", 2022, "BEV"), nil, nil)
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/core/services/powertrain_type_service_test.go
+++ b/internal/core/services/powertrain_type_service_test.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/DIMO-Network/device-definitions-api/internal/infrastructure/gateways"
-	"github.com/segmentio/ksuid"
-
 	mock_gateways "github.com/DIMO-Network/device-definitions-api/internal/infrastructure/gateways/mocks"
 	"go.uber.org/mock/gomock"
 
@@ -129,19 +126,5 @@ func Test_powerTrainTypeService_ResolvePowerTrainType(t *testing.T) {
 
 			assert.Equalf(t, tt.want, got, "ResolvePowerTrainType( %v, %v, %v, %v, %v)", tt.args.makeSlug, tt.args.modelSlug, tt.args.definitionID, tt.args.drivlyData, tt.args.vincarioData)
 		})
-	}
-}
-
-func buildTestTblDD(definitionID, model string, year int, powerTrainType string) *gateways.DeviceDefinitionTablelandModel {
-	return &gateways.DeviceDefinitionTablelandModel{
-		ID:         definitionID,
-		KSUID:      ksuid.New().String(),
-		Model:      model,
-		Year:       year,
-		DeviceType: "vehicle",
-		ImageURI:   "",
-		Metadata: &gateways.DeviceDefinitionMetadata{DeviceAttributes: []gateways.DeviceTypeAttribute{
-			{Name: "powertrain_type", Value: powerTrainType},
-		}},
 	}
 }


### PR DESCRIPTION
# Proposed Changes

noticed some logs where we were errroring trying to make calls to tableland from places that probably don't make sense. better to remove unnecessary checks and logic.
add some hard coded logic for tesla, lucid, etc known ev oems

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->
`decode-vin`

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->