### PR TITLE
allow manual onboarding when VIN decode is low-confidence

### DIFF
--- a/internal/core/queries/decode_vin.go
+++ b/internal/core/queries/decode_vin.go
@@ -246,9 +246,16 @@ func (dc DecodeVINQueryHandler) Handle(ctx context.Context, query *DecodeVINQuer
 		resp.Powertrain = pt
 	}
 
-	// if dd not found in tableland, we want to create it
+	// if dd not found in tableland, we want to create it — but only for high-confidence
+	// provider sources. Low-confidence sources (Japan chassis decoders, etc.) have produced
+	// garbage on-chain DDs (e.g. Model="4D" body-style codes), so we reject here and let
+	// the client fall back to manual make/model/year selection via the picker.
 	if tblDef != nil {
 		resp.DefinitionId = tblDef.ID
+	} else if isLowConfidenceSource(vinInfo.Source) {
+		metrics.InternalError.With(prometheus.Labels{"method": VinErrors}).Inc()
+		localLog.Warn().Str("decode_source", string(vinInfo.Source)).Msgf("low-confidence decode + tableland miss; returning not found so client opens manual picker")
+		return nil, &exceptions.NotFoundError{Err: fmt.Errorf("device definition not found on-chain for low-confidence decode %s (source=%s); manual selection required", tid, vinInfo.Source)}
 	} else {
 		// if any images were added above, they will be in the database
 		latestImages, _ := models.Images(models.ImageWhere.DefinitionID.EQ(resp.DefinitionId)).All(ctx, dc.dbs().Reader)
@@ -521,4 +528,18 @@ func (dc DecodeVINQueryHandler) associateImagesToDeviceDefinition(ctx context.Co
 	}
 
 	return nil
+}
+
+// isLowConfidenceSource returns true for decode providers whose output has historically
+// produced bad on-chain device definitions (e.g., Japanese chassis decoders returning body-style
+// codes as model names). For these sources we refuse to auto-create a DD from a tableland miss
+// and instead surface a NotFoundError so the client can fall back to manual make/model/year
+// selection. High-confidence Western providers (Drivly, Vincario, DATGroup, Tesla) retain the
+// existing auto-create behavior.
+func isLowConfidenceSource(src coremodels.DecodeProviderEnum) bool {
+	switch src {
+	case coremodels.Japan17VIN, coremodels.CarVXVIN, coremodels.AutoIsoProvider, coremodels.ElevaKaufmannProvider:
+		return true
+	}
+	return false
 }

--- a/internal/infrastructure/gateways/japan_17vin_api.go
+++ b/internal/infrastructure/gateways/japan_17vin_api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,15 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/tidwall/gjson"
 )
+
+// bodyStylePattern matches Japanese EPC body-style codes like "4D", "5D", "2D", "4DR", "5HB"
+// which sometimes appear in the "Model Name" column instead of an actual vehicle series.
+var bodyStylePattern = regexp.MustCompile(`^\d+[A-Za-z]{0,3}$`)
+
+// modelNameColumns lists Col_name candidates for the vehicle series, in priority order.
+// 17vin responses vary by brand; docs show "Model name" (lowercase), existing production
+// data used "Model Name", and Chinese-column responses use "车型".
+var modelNameColumns = []string{"Model Name", "Model name", "车型"}
 
 //go:generate mockgen -source japan_17vin_api.go -destination mocks/japan_17vin_api_mock.go -package mocks
 type Japan17VINAPI interface {
@@ -60,24 +70,7 @@ func (j *japan17VINAPI) GetVINInfo(vin string) (*coremodels.Japan17MMY, []byte, 
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to parse year string %s", yearString)
 	}
-	model := ""
-	modelNameProperty := parsed.Get(`data.model_original_epc_list.0.CarAttributes.#(Col_name="Model Name").Col_value`).String()
-	if modelNameProperty != "" {
-		if strings.Contains(modelNameProperty, `/`) {
-			// this means it has two options, sometimes in the additional info it will have the model
-			additionalInfo := parsed.Get(`data.model_original_epc_list.0.CarAttributes.#(Col_name="Additional Vehicle Infomation").Col_value`).String()
-			splitInfo := strings.Split(additionalInfo, " ")
-			if len(splitInfo) > 0 {
-				// grab the first name which is usually the model
-				model = splitInfo[0]
-			} else {
-				// if nothing found then just grab the first value from the model name
-				model = strings.Split(modelNameProperty, "/")[0]
-			}
-		} else {
-			model = modelNameProperty
-		}
-	}
+	model := extractModelName(parsed)
 
 	result := coremodels.Japan17MMY{
 		VIN:                   vin,
@@ -89,6 +82,53 @@ func (j *japan17VINAPI) GetVINInfo(vin string) (*coremodels.Japan17MMY, []byte, 
 
 	return &result, bodyBytes, nil
 }
+
+// extractModelName finds the vehicle series name from the 17vin EPC response,
+// skipping body-style codes like "4D" that sometimes populate the Model Name column.
+func extractModelName(parsed gjson.Result) string {
+	entries := parsed.Get("data.model_original_epc_list").Array()
+	for _, entry := range entries {
+		attrs := entry.Get("CarAttributes")
+		for _, col := range modelNameColumns {
+			raw := attrs.Get(fmt.Sprintf(`#(Col_name=%q).Col_value`, col)).String()
+			candidate := pickModelCandidate(raw)
+			if candidate != "" {
+				return candidate
+			}
+		}
+		// fall back: first token of "Additional Vehicle Infomation"
+		addl := attrs.Get(`#(Col_name="Additional Vehicle Infomation").Col_value`).String()
+		if addl != "" {
+			for t := range strings.FieldsSeq(addl) {
+				if !isBodyStyleCode(t) && len(t) > 1 {
+					return t
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// pickModelCandidate accepts a raw Col_value, splits on "/" for multi-model responses,
+// and returns the first non-body-style entry.
+func pickModelCandidate(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	for p := range strings.SplitSeq(raw, "/") {
+		p = strings.TrimSpace(p)
+		if p != "" && !isBodyStyleCode(p) {
+			return p
+		}
+	}
+	return ""
+}
+
+func isBodyStyleCode(s string) bool {
+	return bodyStylePattern.MatchString(strings.TrimSpace(s))
+}
+
 func md5Hex(s string) string {
 	hash := md5.Sum([]byte(s))
 	return hex.EncodeToString(hash[:])

--- a/internal/infrastructure/gateways/japan_17vin_api.go
+++ b/internal/infrastructure/gateways/japan_17vin_api.go
@@ -85,19 +85,22 @@ func (j *japan17VINAPI) GetVINInfo(vin string) (*coremodels.Japan17MMY, []byte, 
 
 // extractModelName finds the vehicle series name from the 17vin EPC response,
 // skipping body-style codes like "4D" that sometimes populate the Model Name column.
+// When Model Name is a "/"-joined platform list (e.g. "NOAH/VOXY/ESQUIRE"), the
+// Additional Vehicle Infomation field usually names the actual trim — used as
+// a disambiguation hint.
 func extractModelName(parsed gjson.Result) string {
 	entries := parsed.Get("data.model_original_epc_list").Array()
 	for _, entry := range entries {
 		attrs := entry.Get("CarAttributes")
+		addl := attrs.Get(`#(Col_name="Additional Vehicle Infomation").Col_value`).String()
 		for _, col := range modelNameColumns {
 			raw := attrs.Get(fmt.Sprintf(`#(Col_name=%q).Col_value`, col)).String()
-			candidate := pickModelCandidate(raw)
+			candidate := pickModelCandidate(raw, addl)
 			if candidate != "" {
 				return candidate
 			}
 		}
-		// fall back: first token of "Additional Vehicle Infomation"
-		addl := attrs.Get(`#(Col_name="Additional Vehicle Infomation").Col_value`).String()
+		// fall back: first meaningful token of Additional Vehicle Infomation
 		if addl != "" {
 			for t := range strings.FieldsSeq(addl) {
 				if !isBodyStyleCode(t) && len(t) > 1 {
@@ -110,19 +113,33 @@ func extractModelName(parsed gjson.Result) string {
 }
 
 // pickModelCandidate accepts a raw Col_value, splits on "/" for multi-model responses,
-// and returns the first non-body-style entry.
-func pickModelCandidate(raw string) string {
+// and returns the best non-body-style entry. If multiple candidates remain and the
+// hint (additional-info column) contains one of them, that one wins; otherwise the
+// first valid candidate is returned.
+func pickModelCandidate(raw, hint string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return ""
 	}
+	var candidates []string
 	for p := range strings.SplitSeq(raw, "/") {
 		p = strings.TrimSpace(p)
 		if p != "" && !isBodyStyleCode(p) {
-			return p
+			candidates = append(candidates, p)
 		}
 	}
-	return ""
+	if len(candidates) == 0 {
+		return ""
+	}
+	if len(candidates) > 1 && hint != "" {
+		hintUpper := strings.ToUpper(hint)
+		for _, c := range candidates {
+			if strings.Contains(hintUpper, strings.ToUpper(c)) {
+				return c
+			}
+		}
+	}
+	return candidates[0]
 }
 
 func isBodyStyleCode(s string) bool {

--- a/internal/infrastructure/gateways/japan_17vin_api.go
+++ b/internal/infrastructure/gateways/japan_17vin_api.go
@@ -83,12 +83,16 @@ func (j *japan17VINAPI) GetVINInfo(vin string) (*coremodels.Japan17MMY, []byte, 
 	return &result, bodyBytes, nil
 }
 
-// extractModelName finds the vehicle series name from the 17vin EPC response,
-// skipping body-style codes like "4D" that sometimes populate the Model Name column.
-// When Model Name is a "/"-joined platform list (e.g. "NOAH/VOXY/ESQUIRE"), the
-// Additional Vehicle Infomation field usually names the actual trim — used as
-// a disambiguation hint.
+// extractModelName finds the vehicle series name from the 17vin response.
+// Preference order: (1) data.model_list[0].Model_en — 17vin's standardized
+// product name, populated for known 17-char VINs; (2) the EPC
+// model_original_epc_list attributes, which may carry raw internal model
+// names with body-style codes, parenthetical factory tags, or multi-model
+// platform lists (e.g. "NOAH/VOXY/ESQUIRE").
 func extractModelName(parsed gjson.Result) string {
+	if std := sanitizeModelName(parsed.Get("data.model_list.0.Model_en").String()); std != "" {
+		return std
+	}
 	entries := parsed.Get("data.model_original_epc_list").Array()
 	for _, entry := range entries {
 		attrs := entry.Get("CarAttributes")
@@ -104,7 +108,7 @@ func extractModelName(parsed gjson.Result) string {
 		if addl != "" {
 			for t := range strings.FieldsSeq(addl) {
 				if !isBodyStyleCode(t) && len(t) > 1 {
-					return t
+					return sanitizeModelName(t)
 				}
 			}
 		}
@@ -112,12 +116,22 @@ func extractModelName(parsed gjson.Result) string {
 	return ""
 }
 
+// sanitizeModelName strips characters that don't belong in a slugged model
+// name: parenthetical factory tags like "(TMMC" and trailing commas.
+func sanitizeModelName(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, "(,"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}
+
 // pickModelCandidate accepts a raw Col_value, splits on "/" for multi-model responses,
 // and returns the best non-body-style entry. If multiple candidates remain and the
 // hint (additional-info column) contains one of them, that one wins; otherwise the
-// first valid candidate is returned.
+// first valid candidate is returned. Parenthetical suffixes are stripped.
 func pickModelCandidate(raw, hint string) string {
-	raw = strings.TrimSpace(raw)
+	raw = sanitizeModelName(raw)
 	if raw == "" {
 		return ""
 	}

--- a/internal/infrastructure/gateways/japan_17vin_api_test.go
+++ b/internal/infrastructure/gateways/japan_17vin_api_test.go
@@ -232,6 +232,21 @@ func Test_extractModelName_realPayloads(t *testing.T) {
 			]}]}}`,
 			want: "CROWN",
 		},
+		{
+			name: "212HGCEZ3NC010151 Lexus NX — prefer model_list.Model_en",
+			payload: `{"data":{"model_list":[{"Model_en":"NX 350","Brand_en":"Lexus"}],"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"LEXUS NX SERIES(TMMC"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"LHD  TBO  USA"}
+			]}]}}`,
+			want: "NX 350",
+		},
+		{
+			name: "paren stripped even when model_list absent",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"LEXUS NX SERIES(TMMC"}
+			]}]}}`,
+			want: "LEXUS NX SERIES",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/infrastructure/gateways/japan_17vin_api_test.go
+++ b/internal/infrastructure/gateways/japan_17vin_api_test.go
@@ -92,3 +92,28 @@ func Test_extractModelName_chineseFallback(t *testing.T) {
 func Test_extractModelName_empty(t *testing.T) {
 	assert.Equal(t, "", extractModelName(gjson.Parse(`{"data":{}}`)))
 }
+
+// Regression: real 17vin response for GWS214-6014148 (Toyota Crown Hybrid).
+// Previously yielded "4D" from the "Additional Vehicle Infomation" column and
+// got minted on-chain as toyota_4d_2017.
+func Test_extractModelName_gws214Crown(t *testing.T) {
+	payload := `{
+		"data": {
+			"epc": "toyota",
+			"model_year_from_vin": "2017",
+			"model_original_epc_list": [{
+				"CarAttributes": [
+					{"Col_name": "车型", "Col_value": "CROWN/HYBRID"},
+					{"Col_name": "Model Name", "Col_value": "CROWN/HYBRID"},
+					{"Col_name": "车型代码", "Col_value": "GWS214-AEXZB"},
+					{"Col_name": "Model Code", "Col_value": "GWS214-AEXZB"},
+					{"Col_name": "车身", "Col_value": "SED"},
+					{"Col_name": "Body", "Col_value": "SED"},
+					{"Col_name": "Engine Code", "Col_value": "2GRFXE"},
+					{"Col_name": "Additional Vehicle Infomation", "Col_value": "4D   HTWC"}
+				]
+			}]
+		}
+	}`
+	assert.Equal(t, "CROWN", extractModelName(gjson.Parse(payload)))
+}

--- a/internal/infrastructure/gateways/japan_17vin_api_test.go
+++ b/internal/infrastructure/gateways/japan_17vin_api_test.go
@@ -26,11 +26,16 @@ func Test_isBodyStyleCode(t *testing.T) {
 }
 
 func Test_pickModelCandidate(t *testing.T) {
-	assert.Equal(t, "Crown", pickModelCandidate("Crown"))
-	assert.Equal(t, "CAMRY", pickModelCandidate("CAMRY/HYBRID"))
-	assert.Equal(t, "Crown", pickModelCandidate("4D/Crown"))
-	assert.Equal(t, "", pickModelCandidate("4D"))
-	assert.Equal(t, "", pickModelCandidate(""))
+	assert.Equal(t, "Crown", pickModelCandidate("Crown", ""))
+	assert.Equal(t, "CAMRY", pickModelCandidate("CAMRY/HYBRID", ""))
+	assert.Equal(t, "Crown", pickModelCandidate("4D/Crown", ""))
+	assert.Equal(t, "", pickModelCandidate("4D", ""))
+	assert.Equal(t, "", pickModelCandidate("", ""))
+	// hint picks the platform variant actually built
+	assert.Equal(t, "VOXY", pickModelCandidate("NOAH/VOXY", "VOXY 07S  HTWC CBU"))
+	assert.Equal(t, "VOXY", pickModelCandidate("NOAH/VOXY/ESQUIRE", "VOXY 07S  HTWVMCBU"))
+	// hint irrelevant when it doesn't match any candidate: first wins
+	assert.Equal(t, "CROWN", pickModelCandidate("CROWN/HYBRID", "4D   HTWC"))
 }
 
 func Test_extractModelName_rejectsBodyStyle(t *testing.T) {
@@ -91,6 +96,148 @@ func Test_extractModelName_chineseFallback(t *testing.T) {
 
 func Test_extractModelName_empty(t *testing.T) {
 	assert.Equal(t, "", extractModelName(gjson.Parse(`{"data":{}}`)))
+}
+
+// Data-driven regression suite using real 17vin payloads. Each case pairs the
+// full `data.model_original_epc_list` attributes with the model name we expect
+// the adapter to surface (compare against the DD slug historically indexed).
+func Test_extractModelName_realPayloads(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{
+			name: "JTDZN3EU8HJ060118 Prius v",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"PRIUS V"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"05S  USA"}
+			]}]}}`,
+			want: "PRIUS V",
+		},
+		{
+			name: "TRJ150-0081549 Land Cruiser Prado",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"LAND CRUISER PRADO"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"5D   07S"}
+			]}]}}`,
+			want: "LAND CRUISER PRADO",
+		},
+		{
+			name: "GRX120-3043102 Mark X",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"MARK X"}
+			]}]}}`,
+			want: "MARK X",
+		},
+		{
+			name: "JTEBU29J940026005 Land Cruiser Prado",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"LAND CRUISER PRADO"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"LHD  5D"}
+			]}]}}`,
+			want: "LAND CRUISER PRADO",
+		},
+		{
+			name: "ZWR90-8000186 Voxy (NOAH/VOXY disambiguated by addl info)",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"NOAH/VOXY"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"VOXY 07S  HTWC CBU"}
+			]}]}}`,
+			want: "VOXY",
+		},
+		{
+			name: "3TYLC5LN5ST036165 Tacoma",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"TACOMA"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"DCB"}
+			]}]}}`,
+			want: "TACOMA",
+		},
+		{
+			name: "A210A-0012622 Raize",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"RAIZE"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"5D   05S"}
+			]}]}}`,
+			want: "RAIZE",
+		},
+		{
+			name: "AGH30-0397617 Alphard (previously ALPHD07S bug)",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"ALPHARD/VELLFIRE/HV"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"ALPHD07S"}
+			]}]}}`,
+			want: "ALPHARD",
+		},
+		{
+			name: "ZVW60-4006778 Prius",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"PRIUS"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"5D"}
+			]}]}}`,
+			want: "PRIUS",
+		},
+		{
+			name: "ZRR80-0413374 Voxy (NOAH/VOXY/ESQUIRE disambiguated)",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"NOAH/VOXY/ESQUIRE"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"VOXY 07S  HTWVMCBU"}
+			]}]}}`,
+			want: "VOXY",
+		},
+		{
+			name: "SJNFAAJ11U2132164 Qashqai UK Make",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"QASHQAI UK MAKE"}
+			]}]}}`,
+			want: "QASHQAI UK MAKE",
+		},
+		{
+			name: "NHP10-6705283 Aqua",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"AQUA"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"5D"}
+			]}]}}`,
+			want: "AQUA",
+		},
+		{
+			name: "NHP170-7078636 Sienta",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"SIENTA"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"07S  HTWC"}
+			]}]}}`,
+			want: "SIENTA",
+		},
+		{
+			name: "7MUAAABG3PV055668 Corolla Cross",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"COROLLA CROSS"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"LHD"}
+			]}]}}`,
+			want: "COROLLA CROSS",
+		},
+		{
+			name: "SUNFAAZE1U0009011 Leaf UK Make",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"LEAF UK MAKE"}
+			]}]}}`,
+			want: "LEAF UK MAKE",
+		},
+		{
+			name: "GWS214-6014148 Crown (slash with HYBRID variant)",
+			payload: `{"data":{"model_original_epc_list":[{"CarAttributes":[
+				{"Col_name":"Model Name","Col_value":"CROWN/HYBRID"},
+				{"Col_name":"Additional Vehicle Infomation","Col_value":"4D   HTWC"}
+			]}]}}`,
+			want: "CROWN",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, extractModelName(gjson.Parse(tc.payload)))
+		})
+	}
 }
 
 // Regression: real 17vin response for GWS214-6014148 (Toyota Crown Hybrid).

--- a/internal/infrastructure/gateways/japan_17vin_api_test.go
+++ b/internal/infrastructure/gateways/japan_17vin_api_test.go
@@ -1,0 +1,94 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func Test_isBodyStyleCode(t *testing.T) {
+	cases := map[string]bool{
+		"4D":    true,
+		"5D":    true,
+		"2D":    true,
+		"4DR":   true,
+		"5HB":   true,
+		"123":   true,
+		"Crown": false,
+		"CAMRY": false,
+		"":      false,
+		"Q7":    false, // letter+digit, not digit-leading
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, isBodyStyleCode(in), "input %q", in)
+	}
+}
+
+func Test_pickModelCandidate(t *testing.T) {
+	assert.Equal(t, "Crown", pickModelCandidate("Crown"))
+	assert.Equal(t, "CAMRY", pickModelCandidate("CAMRY/HYBRID"))
+	assert.Equal(t, "Crown", pickModelCandidate("4D/Crown"))
+	assert.Equal(t, "", pickModelCandidate("4D"))
+	assert.Equal(t, "", pickModelCandidate(""))
+}
+
+func Test_extractModelName_rejectsBodyStyle(t *testing.T) {
+	// simulates prior bug: Model Name column held "4D"; series name lives in additional info.
+	payload := `{
+		"data": {
+			"model_original_epc_list": [{
+				"CarAttributes": [
+					{"Col_name": "Model Name", "Col_value": "4D"},
+					{"Col_name": "Additional Vehicle Infomation", "Col_value": "Crown Hybrid"}
+				]
+			}]
+		}
+	}`
+	got := extractModelName(gjson.Parse(payload))
+	assert.Equal(t, "Crown", got)
+}
+
+func Test_extractModelName_prefersModelNameWhenValid(t *testing.T) {
+	payload := `{
+		"data": {
+			"model_original_epc_list": [{
+				"CarAttributes": [
+					{"Col_name": "Model Name", "Col_value": "CAMRY/HYBRID"},
+					{"Col_name": "Additional Vehicle Infomation", "Col_value": "LHD CHI"}
+				]
+			}]
+		}
+	}`
+	assert.Equal(t, "CAMRY", extractModelName(gjson.Parse(payload)))
+}
+
+func Test_extractModelName_fallsThroughColumnVariants(t *testing.T) {
+	payload := `{
+		"data": {
+			"model_original_epc_list": [{
+				"CarAttributes": [
+					{"Col_name": "Model name", "Col_value": "Crown"}
+				]
+			}]
+		}
+	}`
+	assert.Equal(t, "Crown", extractModelName(gjson.Parse(payload)))
+}
+
+func Test_extractModelName_chineseFallback(t *testing.T) {
+	payload := `{
+		"data": {
+			"model_original_epc_list": [{
+				"CarAttributes": [
+					{"Col_name": "车型", "Col_value": "Crown"}
+				]
+			}]
+		}
+	}`
+	assert.Equal(t, "Crown", extractModelName(gjson.Parse(payload)))
+}
+
+func Test_extractModelName_empty(t *testing.T) {
+	assert.Equal(t, "", extractModelName(gjson.Parse(`{"data":{}}`)))
+}


### PR DESCRIPTION
## Summary

Stops silent on-chain creation of garbage device definitions from low-confidence VIN decoders and hardens the Japan 17vin adapter.

### Background
Japanese engineers onboarding vehicles hit two failures:
- `GWS214-6014148` (Toyota Crown chassis) decoded via japan17vin as `Model="4D"` (body-style code), then got auto-registered on-chain as `toyota_4d_2017`. Client subsequently crashed trying to render the bad DD.
- Root cause: `japan_17vin_api.go` extracted model from a column that sometimes holds body-style codes, and `decode_vin.go` unconditionally created an on-chain DD on tableland miss regardless of how shaky the decode was.

### Changes
1. **`internal/infrastructure/gateways/japan_17vin_api.go`** — robust model extraction:
   - Tries `Model Name`, `Model name`, `车型` in priority order.
   - Rejects body-style codes matching `^\d+[A-Za-z]{0,3}$` (4D, 5D, 2D, 5HB).
   - Falls through to first non-body-style token in `Additional Vehicle Infomation`.
   - New unit tests.

2. **`internal/core/queries/decode_vin.go`** — gate auto-create for low-confidence sources:
   - If source is `japan17vin`, `carvxvin`, `autoiso`, or `eleva` and tableland returns no match → return `NotFoundError` instead of calling `Create()`.
   - Client (separate PR) catches this and opens the manual make/model/year picker.
   - High-confidence sources (Drivly, Vincario, DATGroup, Tesla) keep existing auto-create.

### Out of scope
- Cleaning up existing bad on-chain DDs (e.g., `toyota_4d_2017`).
- JPN 11-char chassis 500 for `GJ5FW-550049` (separate issue in shared `pkg/vin.IsValidJapanChassis()`).

## Test plan
- [x] `go test -race ./internal/infrastructure/gateways/...` — green, includes new japan17vin extraction tests.
- [x] `go build ./...` — clean.
- [x] `golangci-lint run` — no new issues.
- [ ] Local decode of `GWS214-6014148` with `countryCode=JPN` returns error (not a new on-chain DD).
- [ ] Local decode of a high-confidence VIN with tableland miss still auto-creates (regression check).
- [ ] End-to-end with dimo-driver companion PR: app opens picker on decode failure.